### PR TITLE
Parse HTTP authorization headers

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -72,7 +72,7 @@ class Auth0Strategy extends AuthenticationBaseStrategy {
   /**
    * Takes a JWK object and returns a valid key in PEM format. Throws
    * a GeneralError if there are no x5c items stored on the JWK.
-   * 
+   *
    * @param   {String}       jwk The JWK to be parsed
    * @returns {String}           The key in PEM format from the first x5c entry
    * @throws  {GeneralError}     Throws a GeneralError if there are no x5c items
@@ -87,7 +87,7 @@ class Auth0Strategy extends AuthenticationBaseStrategy {
    * Takes a JWKS endpoint URI and returns a Promise that resolves to an
    * array of JWKs, i.e. a JWKS. The resulting function may throw any of
    * [the errors described here]{@link https://github.com/request/promise-core/blob/master/lib/errors.js}
-   * 
+   *
    * @param   {String}   url The URI of the JWKS endpoint
    * @returns {Promise}      A Promise that resolves to JWKS retrieved
    */
@@ -110,10 +110,10 @@ class Auth0Strategy extends AuthenticationBaseStrategy {
   async getJWK (accessToken) {
     // decode the access token (this does not throw an error)
     const token = jwt.decode(accessToken, { complete: true })
-    
+
     // throw an error if the token was malformed or missing
     if (!token) throw new NotAuthenticated('The access token was malformed or missing')
-    
+
     // get the kid from the token header
     const kid = token.header.kid
 
@@ -161,7 +161,7 @@ class Auth0Strategy extends AuthenticationBaseStrategy {
       connection.authentication &&
       authResult &&
       connection.authentication.accessToken === authResult.accessToken
-    
+
     const { accessToken } = authResult || {}
 
     if (accessToken && event === 'login') {
@@ -292,6 +292,22 @@ class Auth0Strategy extends AuthenticationBaseStrategy {
       },
       [entity]: user
     }
+  }
+
+  /**
+   * Extracts the accessToken from a HTTP request object's Authorization header.
+   *
+   * @param   {Object} req            Express request object
+   * @returns {Object}                Contains the token and strategy name
+   */
+  parse (req) {
+    if (req.headers.authorization) {
+      return {
+        strategy: this.name,
+        accessToken: req.headers.authorization.split(' ').pop()
+      }
+    }
+    return null
   }
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -294,6 +294,40 @@ describe('The Auth0Strategy', () => {
     })
 
   })
+
+  describe('parse() method', () => {
+    it('is a function', () => {
+      assert(typeof strategy.parse === 'function', 'parse() is not a function.')
+    })
+    it('extracts an accessToken value from an HTTP header scheme', () => {
+      const result = strategy.parse({
+        headers: {
+          authorization: 'Bearer the_token_value'
+        }
+      })
+      assert.deepEqual(result, {
+        strategy: 'auth0',
+        accessToken: 'the_token_value'
+      }, 'The expected parse() result was not returned')
+    })
+    it('extracts the accessToken value from a plain HTTP header', () => {
+      const result = strategy.parse({
+        headers: {
+          authorization: 'the_token_value'
+        }
+      })
+      assert.deepEqual(result, {
+        strategy: 'auth0',
+        accessToken: 'the_token_value'
+      }, 'The expected parse() result was not returned')
+    })
+    it('returns null for an absent header', () => {
+      const result = strategy.parse({
+        headers: {}
+      })
+      assert.strictEqual(result, null, 'Malformed parse() result')
+    })
+  })
 })
 
 describe('The Auth0Service', () => {
@@ -606,7 +640,7 @@ describe('The Auth0Service', () => {
         )
       }
     })
-    
+
     it('throws an error if called from an error context', async () => {
       try {
         await authenticateHook(contexts.errorContext)
@@ -620,7 +654,7 @@ describe('The Auth0Service', () => {
         )
       }
     })
-    
+
     it('throws an error if trying to authenticate the `/authentication` path', async () => {
       const authContext = {
         app,
@@ -728,22 +762,22 @@ describe('The Auth0Service', () => {
     it('is a function', () => {
       assert(typeof fromAuth0Hook === 'function', 'fromAuth0() is not a function.')
     })
-    
+
     it('returns true if the request context comes from a whitelisted IP address', async () => {
       const isWhitelisted = await fromAuth0Hook(contexts.fromAuth0Context)
       assert(isWhitelisted, 'an IP address on the whitelist was rejected')
     })
-    
+
     it('returns true if the request context comes from a European whitelisted IP address', async () => {
       const isWhitelisted = await fromEuropeanAuth0Hook(contexts.fromEuropeanAuth0Context)
       assert(isWhitelisted, 'an IP address on the whitelist was rejected')
     })
-    
+
     it('returns true if the request context comes from an Australian whitelisted IP address', async () => {
       const isWhitelisted = await fromAustralianAuth0Hook(contexts.fromAustralianAuth0Context)
       assert(isWhitelisted, 'an IP address on the whitelist was rejected')
     })
-    
+
     it('returns false if the request context comes from a non-whitelisted IP address', async () => {
       const isWhitelisted = await fromAuth0Hook(contexts.notFromAuth0Context)
       assert(!isWhitelisted, 'an IP address not on the whitelist was accepted')
@@ -888,7 +922,7 @@ describe('The Auth0Service', () => {
 describe('The addIP middleware', () => {
   it('should be registered', () => {
     assert(
-      app._router && app._router.stack && app._router.stack.some(mw => mw.name === 'addIP'), 
+      app._router && app._router.stack && app._router.stack.some(mw => mw.name === 'addIP'),
       'the addIP middleware was not registered'
     )
   })


### PR DESCRIPTION
Not really sure if I did something wrong, but I felt this needed the parse method on the Auth0Strategy class when dealing with REST requests. Otherwise I always end up unauthenticated because the header doesn't seem to be extracted anywhere.

It now works and did not before so I thought I'd create a pull request instead of an issue.

Cheers to this great module!